### PR TITLE
Fix "mixed content" error when serving over SSL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <head>
 <link rel="stylesheet" href="style.css" />
 
-	<script src="http://code.jquery.com/jquery-latest.min.js " ></script>
+	<script src="//code.jquery.com/jquery-latest.min.js " ></script>
 	<title>mapstarter</title>
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-	<script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
+	<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet-src.js"></script>
 	<script src="cities.js"></script>	
 	<script type="text/javascript">
 


### PR DESCRIPTION
Hi @ladyshisha! 

Saw your map page was looking a little bare. This isn't your fault, but rather my fault for getting you a bad template to start with. 😞  

Specifically, if you'd opened your browser console you would have seen an error like this:
<img width="658" alt="screen shot 2016-06-28 at 10 06 15 am" src="https://cloud.githubusercontent.com/assets/217057/16425179/33260de8-3d18-11e6-8d27-5bbd61181cdf.png">

This error was preventing the map JS code from loading. 

If you merge this pull request (and wait 60 seconds), you should see an _actual map_ on your page: https://ladyshisha.github.io/mapstarter/. 🎉 
